### PR TITLE
fix: make the event tap survive, and stop the synthetic Cmd+C from cancelling the cut

### DIFF
--- a/cmdX/KeyInterceptor.swift
+++ b/cmdX/KeyInterceptor.swift
@@ -1,5 +1,4 @@
 import Cocoa
-import Carbon
 import Combine
 
 final class KeyInterceptor: ObservableObject {
@@ -34,7 +33,7 @@ final class KeyInterceptor: ObservableObject {
                                      userInfo: nil)
 
         guard let eventTap = eventTap else {
-            NSLog("cmdX: failed to create event tap - make sure Input Monitoring is allowed")
+            NSLog("cmdX: failed to create event tap - grant Accessibility access in System Settings > Privacy & Security")
             return
         }
 
@@ -83,33 +82,36 @@ final class KeyInterceptor: ObservableObject {
         }
 
         let flags = event.flags
-        let isCmd = flags.contains(.maskCommand)
-
-        if let chars = event.keyboardGetUnicodeString() {
-            let s = chars.lowercased()
-            if isCmd && s == "x" {
-                shared.cutPending = true
-                shared.publishCutState(true)
-                postShortcut(keyCode: kVK_ANSI_C, flags: [.maskCommand])
-                return nil
-            }
-            if isCmd && s == "c" {
-                shared.cutPending = false
-                shared.publishCutState(false)
-                return Unmanaged.passUnretained(event)
-            }
-            if isCmd && s == "v" {
-                guard shared.cutPending else {
-                    return Unmanaged.passUnretained(event)
-                }
-                shared.cutPending = false
-                shared.publishCutState(false)
-                postShortcut(keyCode: kVK_ANSI_V, flags: [.maskCommand, .maskAlternate])
-                return nil
-            }
+        guard flags.contains(.maskCommand),
+              !flags.contains(.maskAlternate),
+              !flags.contains(.maskControl) else {
+            return Unmanaged.passUnretained(event)
         }
 
-        return Unmanaged.passUnretained(event)
+        switch CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode)) {
+        case Keycode.x:
+            shared.cutPending = true
+            shared.publishCutState(true)
+            postShortcut(keyCode: Keycode.c, flags: [.maskCommand])
+            return nil
+
+        case Keycode.c:
+            shared.cutPending = false
+            shared.publishCutState(false)
+            return Unmanaged.passUnretained(event)
+
+        case Keycode.v:
+            guard shared.cutPending else {
+                return Unmanaged.passUnretained(event)
+            }
+            shared.cutPending = false
+            shared.publishCutState(false)
+            postShortcut(keyCode: Keycode.v, flags: [.maskCommand, .maskAlternate])
+            return nil
+
+        default:
+            return Unmanaged.passUnretained(event)
+        }
     }
 
     private func publishCutState(_ value: Bool) {
@@ -119,18 +121,10 @@ final class KeyInterceptor: ObservableObject {
     }
 }
 
-
-private extension CGEvent {
-    func keyboardGetUnicodeString() -> String? {
-        let length: Int = 4
-        var chars = [UniChar](repeating: 0, count: length)
-        var actualLength: Int = 0
-        self.keyboardGetUnicodeString(maxStringLength: length, actualStringLength: &actualLength, unicodeString: &chars)
-        if actualLength > 0 {
-            return String(utf16CodeUnits: chars, count: actualLength)
-        }
-        return nil
-    }
+private enum Keycode {
+    static let x: CGKeyCode = 7
+    static let c: CGKeyCode = 8
+    static let v: CGKeyCode = 9
 }
 
 private func isFrontmostAppFinder() -> Bool {
@@ -156,7 +150,3 @@ private func postShortcut(keyCode: CGKeyCode, flags: CGEventFlags) {
     keyDown.post(tap: .cgAnnotatedSessionEventTap)
     keyUp.post(tap: .cgAnnotatedSessionEventTap)
 }
-
-private let kVK_ANSI_X: CGKeyCode = 7
-private let kVK_ANSI_C: CGKeyCode = 8
-private let kVK_ANSI_V: CGKeyCode = 9

--- a/cmdX/KeyInterceptor.swift
+++ b/cmdX/KeyInterceptor.swift
@@ -57,6 +57,14 @@ final class KeyInterceptor: ObservableObject {
     }
 
     private static func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = shared.eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+                NSLog("cmdX: event tap re-enabled after \(type == .tapDisabledByTimeout ? "timeout" : "user input")")
+            }
+            return nil
+        }
+
         guard type == .keyDown else {
             return Unmanaged.passUnretained(event)
         }

--- a/cmdX/KeyInterceptor.swift
+++ b/cmdX/KeyInterceptor.swift
@@ -11,6 +11,10 @@ final class KeyInterceptor: ObservableObject {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
+    private var cutPending = false
+
+    fileprivate static let syntheticMarker: Int64 = 0x636D_6458
+
     init() {}
 
     func start() {
@@ -53,6 +57,7 @@ final class KeyInterceptor: ObservableObject {
         runLoopSource = nil
         eventTap = nil
         isRunning = false
+        cutPending = false
         NSLog("cmdX: event tap stopped")
     }
 
@@ -69,60 +74,47 @@ final class KeyInterceptor: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        if !isFrontmostAppFinder() {
+        if event.getIntegerValueField(.eventSourceUserData) == syntheticMarker {
+            return Unmanaged.passUnretained(event)
+        }
+
+        guard isFrontmostAppFinder() else {
             return Unmanaged.passUnretained(event)
         }
 
         let flags = event.flags
-
-        if KeyInterceptor.isPosting {
-            return Unmanaged.passUnretained(event)
-        }
-
         let isCmd = flags.contains(.maskCommand)
-        
+
         if let chars = event.keyboardGetUnicodeString() {
             let s = chars.lowercased()
             if isCmd && s == "x" {
-                KeyInterceptor.isPosting = true
-                postKeySequence(copyOnly: true)
-                KeyInterceptor.isPosting = false
-                shared.setCutState(true)
+                shared.cutPending = true
+                shared.publishCutState(true)
+                postShortcut(keyCode: kVK_ANSI_C, flags: [.maskCommand])
                 return nil
             }
             if isCmd && s == "c" {
-                shared.setCutState(false)
+                shared.cutPending = false
+                shared.publishCutState(false)
                 return Unmanaged.passUnretained(event)
             }
             if isCmd && s == "v" {
-                if shared.lastActionWasCut {
-                    KeyInterceptor.isPosting = true
-                    postKeySequence(pasteMove: true)
-                    KeyInterceptor.isPosting = false
-                    shared.setCutState(false)
-                    return nil
+                guard shared.cutPending else {
+                    return Unmanaged.passUnretained(event)
                 }
-                return Unmanaged.passUnretained(event)
+                shared.cutPending = false
+                shared.publishCutState(false)
+                postShortcut(keyCode: kVK_ANSI_V, flags: [.maskCommand, .maskAlternate])
+                return nil
             }
         }
 
         return Unmanaged.passUnretained(event)
     }
 
-    private func setCutState(_ v: Bool) {
+    private func publishCutState(_ value: Bool) {
         DispatchQueue.main.async {
-            self.lastActionWasCut = v
-        }
-    }
-    
-    private static func postKeySequence(copyOnly: Bool = false, pasteMove: Bool = false) {
-        if copyOnly {
-            postShortcut(keyCode: kVK_ANSI_C, flags: [.maskCommand])
-            return
-        }
-        if pasteMove {
-            postShortcut(keyCode: kVK_ANSI_V, flags: [.maskCommand, .maskAlternate])
-            return
+            self.lastActionWasCut = value
         }
     }
 }
@@ -150,18 +142,21 @@ private func isFrontmostAppFinder() -> Bool {
 
 private func postShortcut(keyCode: CGKeyCode, flags: CGEventFlags) {
     let src = CGEventSource(stateID: .hidSystemState)
-    let keyDown = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true)
-    keyDown?.flags = flags
-    let keyUp = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false)
-    keyUp?.flags = flags
-    keyDown?.post(tap: .cgAnnotatedSessionEventTap)
-    keyUp?.post(tap: .cgAnnotatedSessionEventTap)
+    guard let keyDown = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: true),
+          let keyUp = CGEvent(keyboardEventSource: src, virtualKey: keyCode, keyDown: false) else {
+        NSLog("cmdX: failed to synthesize keystroke \(keyCode)")
+        return
+    }
+
+    for event in [keyDown, keyUp] {
+        event.flags = flags
+        event.setIntegerValueField(.eventSourceUserData, value: KeyInterceptor.syntheticMarker)
+    }
+
+    keyDown.post(tap: .cgAnnotatedSessionEventTap)
+    keyUp.post(tap: .cgAnnotatedSessionEventTap)
 }
 
 private let kVK_ANSI_X: CGKeyCode = 7
 private let kVK_ANSI_C: CGKeyCode = 8
 private let kVK_ANSI_V: CGKeyCode = 9
-
-extension KeyInterceptor {
-    fileprivate static var isPosting = false
-}


### PR DESCRIPTION
Cmd+X pasted a copy instead of moving the file, and the interceptor went fully deaf after a while. Three separate causes, one commit each.

### 1. The synthetic Cmd+C cleared the cut state

On Cmd+X the interceptor synthesizes a Cmd+C. That event travels back through our own tap and matched the Cmd+C branch, which calls `setCutState(false)` — undoing the cut that was just registered.

`isPosting` could not prevent it. `CGEvent.post` is asynchronous, so the flag was set and cleared entirely before the synthetic event ever reached the callback:

```swift
KeyInterceptor.isPosting = true
postKeySequence(copyOnly: true)   // async
KeyInterceptor.isPosting = false  // already false when the event arrives
shared.setCutState(true)
```

Cmd+V then read `lastActionWasCut == false`, passed the event through, and the Finder did a plain copy — source file left in place.

Fixed by tagging synthesized events in `eventSourceUserData` and skipping them on the way back in. The tag travels with the event, so it holds no matter the delay. The cut state also moved to a plain `cutPending` property read and written from the callback only; `@Published lastActionWasCut` is now just a UI mirror instead of driving the decision through an async hop.

### 2. The tap was never re-armed

macOS delivers `.tapDisabledByTimeout` and `.tapDisabledByUserInput` to the callback regardless of the event mask, and disables the tap when it does. Both fell into the `guard type == .keyDown` and were dropped, so once the system cut the tap it stayed dead for the rest of the process lifetime — `isRunning` still true, 0% CPU, nothing intercepted until relaunch.

Reproduced on an instance that had been running for 15 days.

### 3. Shortcut matching was layout dependent

`keyboardGetUnicodeString` translates through the active keyboard layout and returns an empty string while Command is held on several layouts, so the branches silently stopped matching. Now matching on `.keyboardEventKeycode`.

Also requires Command *without* Option or Control — the previous check only looked for Command, so it swallowed the Finder's own Cmd+Option+V.

### Testing

Built against the current `main` with Xcode 26.3 on macOS 26.0.1 (Apple silicon). Each of the three commits builds clean on its own. Verified by hand in the Finder: Cmd+X then Cmd+V now moves the file; Cmd+C then Cmd+V still copies; Cmd+Option+V passes through to the Finder untouched.

No behaviour change beyond the three fixes, no new dependency, one file touched.