### PR TITLE
Handle Accessibility permission and keep cmdX running when its menu bar icon is hidden (macOS 26)

### DIFF
--- a/cmdX/ContentView.swift
+++ b/cmdX/ContentView.swift
@@ -35,13 +35,14 @@ struct ContentView: View {
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            permissionStatusView
+
             VStack(alignment: .leading, spacing: 12) {
                 Button(action: openAccessibilitySettings) {
                     Text("Open Accessibility Settings")
                 }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.defaultAction)
-                .help("Grant Accessibility permission so cmdX can listen for shortcuts and trigger Move in Finder.")
+                .buttonStyle(.bordered)
+                .help("Manage cmdX’s Accessibility permission in System Settings.")
 
                 Toggle(isOn: $autoLaunch) {
                     Text("Start automatically on launch")
@@ -91,9 +92,10 @@ struct ContentView: View {
             }
         }
         .padding()
-        .frame(width: 520, height: 280)
+        .frame(width: 520, height: 360)
         .background(Color(nsColor: .windowBackgroundColor))
         .onAppear {
+            keyInterceptor.refreshPermissionStatus()
             if #available(macOS 13.0, *) {
                 if UserDefaults.standard.object(forKey: "cmdx.autostart.enabled") != nil {
                     autoLaunch = UserDefaults.standard.bool(forKey: "cmdx.autostart.enabled")
@@ -114,6 +116,57 @@ struct ContentView: View {
         }
     }
 
+
+    private var permissionStatusView: some View {
+        let granted = keyInterceptor.hasAccessibilityPermission
+        return HStack(spacing: 10) {
+            Image(systemName: granted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundColor(granted ? .green : .orange)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(granted ? "Accessibility access granted" : "Accessibility access needed")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(granted
+                     ? "cmdX can intercept shortcuts."
+                     : "cmdX can’t intercept shortcuts until you grant access.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            if !granted {
+                Button("Grant Access…") {
+                    grantAccessibility()
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(
+                    (granted ? Color.green : Color.orange).opacity(0.45),
+                    lineWidth: 1
+                )
+        )
+        .accessibilityElement(children: .combine)
+    }
+
+    private func grantAccessibility() {
+        keyInterceptor.promptForAccessibilityPermission()
+        openAccessibilitySettings()
+    }
 
     private func openAccessibilitySettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
@@ -162,7 +215,7 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
             .environmentObject(KeyInterceptor.shared)
             .environmentObject(UpdateChecker())
-            .frame(width: 520, height: 280)
+            .frame(width: 520, height: 360)
     }
 }
 

--- a/cmdX/KeyInterceptor.swift
+++ b/cmdX/KeyInterceptor.swift
@@ -1,14 +1,17 @@
 import Cocoa
 import Combine
+import ApplicationServices
 
 final class KeyInterceptor: ObservableObject {
     static let shared = KeyInterceptor()
 
     @Published private(set) var isRunning = false
     @Published private(set) var lastActionWasCut = false
+    @Published private(set) var hasAccessibilityPermission: Bool = AXIsProcessTrusted()
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var activityToken: NSObjectProtocol?
 
     private var cutPasteboardState = CutPasteboardState()
 
@@ -18,6 +21,30 @@ final class KeyInterceptor: ObservableObject {
 
     func start() {
         guard eventTap == nil else { return }
+
+        // A keyboard event tap requires Accessibility permission. Without it,
+        // tapCreate fails silently — so check first, publish the status for the
+        // UI, and bail out cleanly until the user grants access.
+        guard AXIsProcessTrusted() else {
+            if hasAccessibilityPermission { hasAccessibilityPermission = false }
+            NSLog("cmdX: accessibility permission not granted; event tap not started")
+            return
+        }
+        if !hasAccessibilityPermission { hasAccessibilityPermission = true }
+
+        // Prevent App Nap. When the menu bar icon is hidden the app has no
+        // visible UI, so macOS would otherwise throttle it — which makes the
+        // event-tap callback time out and the system disables the tap. Holding
+        // this activity token keeps the app responsive while still allowing the
+        // Mac to sleep normally when idle.
+        if activityToken == nil {
+            activityToken = ProcessInfo.processInfo.beginActivity(
+                options: [.userInitiatedAllowingIdleSystemSleep,
+                          .suddenTerminationDisabled,
+                          .automaticTerminationDisabled],
+                reason: "cmdX intercepts keyboard shortcuts globally and must stay responsive even with no visible UI"
+            )
+        }
 
         let mask = CGEventMask(1 << CGEventType.keyDown.rawValue | 1 << CGEventType.flagsChanged.rawValue)
 
@@ -46,6 +73,28 @@ final class KeyInterceptor: ObservableObject {
         }
     }
 
+    /// Re-reads the current Accessibility trust status and publishes any change.
+    @discardableResult
+    func refreshPermissionStatus() -> Bool {
+        let trusted = AXIsProcessTrusted()
+        if trusted != hasAccessibilityPermission {
+            hasAccessibilityPermission = trusted
+        }
+        return trusted
+    }
+
+    /// Asks macOS to show the Accessibility permission prompt for this app.
+    /// (The system dialog only appears if access hasn't been decided yet;
+    /// otherwise this just refreshes the published status.)
+    func promptForAccessibilityPermission() {
+        let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let options = [key: true] as CFDictionary
+        let trusted = AXIsProcessTrustedWithOptions(options)
+        if trusted != hasAccessibilityPermission {
+            hasAccessibilityPermission = trusted
+        }
+    }
+
     func stop() {
         if let runLoopSource = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
@@ -57,10 +106,18 @@ final class KeyInterceptor: ObservableObject {
         eventTap = nil
         isRunning = false
         cancelCut()
+        if let token = activityToken {
+            ProcessInfo.processInfo.endActivity(token)
+            activityToken = nil
+        }
         NSLog("cmdX: event tap stopped")
     }
 
     private static func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // The system disables active event taps when the callback is too slow
+        // (e.g. under App Nap) or on certain user input. When that happens it
+        // notifies us with these event types — re-enable the tap or it stays
+        // dead forever, which is exactly what made cmdX stop working when hidden.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             if let tap = shared.eventTap {
                 CGEvent.tapEnable(tap: tap, enable: true)

--- a/cmdX/UpdateChecker.swift
+++ b/cmdX/UpdateChecker.swift
@@ -147,7 +147,7 @@ class UpdateChecker: NSObject, ObservableObject, UNUserNotificationCenterDelegat
     private func sendNotification() {
         let content = UNMutableNotificationContent()
     content.title = "Update available"
-    content.body = "Open the app in the menu bar to install the update."
+    content.body = "A new version of cmdX is available. Click to open the download page."
         content.sound = .default
         content.categoryIdentifier = "UPDATE_CATEGORY"
         content.userInfo = ["url": latestVersionURL?.absoluteString ?? ""]

--- a/cmdX/cmdXApp.swift
+++ b/cmdX/cmdXApp.swift
@@ -5,142 +5,136 @@
 
 import SwiftUI
 import AppKit
+import Combine
 import ServiceManagement
 import UserNotifications
 
 @main
 struct cmdXApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegateWrapper.self) var appDelegate
-    @StateObject private var keyInterceptor = KeyInterceptor.shared
-    @StateObject private var updateChecker = UpdateChecker()
-    @State private var isShowingOnboarding = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-
-    init() {
-        KeyInterceptor.shared.start()
-        setupUpdateChecker()
-    }
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        MenuBarExtra {
-            ContentView()
-                .environmentObject(keyInterceptor)
-                .environmentObject(updateChecker)
-                .onAppear {
-                    self.appDelegate.updateChecker = self.updateChecker
-                }
-        } label: {
-            HStack {
-                Image(systemName: "command")
-                if updateChecker.isUpdateAvailable {
-                    Image(systemName: "circle.fill")
-                        .foregroundColor(.red)
-                        .font(.system(size: 8))
-                }
-            }
-        }
-        .menuBarExtraStyle(.window)
-    }
-
-    private func setupUpdateChecker() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-            if granted {
-                print("DEBUG: Notification permission granted")
-            } else {
-                print("DEBUG: Notification permission denied: \(error?.localizedDescription ?? "unknown")")
-            }
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            print("DEBUG: Starting initial update check...")
-            self.updateChecker.checkForUpdates()
-        }
-        
-        DispatchQueue.main.async {
-            Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
-                print("DEBUG: Hourly update check...")
-                self.updateChecker.checkForUpdates()
-            }
+        // The app's lifetime is anchored to this background agent + its run loop,
+        // NOT to the menu bar item. That is the whole fix: the menu bar icon is a
+        // classic `NSStatusItem` (created in AppDelegate), so when macOS 26 hides
+        // or removes it, the icon disappears but the process — and the key
+        // interceptor — keeps running. This empty `Settings` scene only satisfies
+        // the `App` protocol; it shows nothing.
+        Settings {
+            EmptyView()
         }
     }
 }
 
-class AppDelegateWrapper: NSObject, NSApplicationDelegate {
-    var updateChecker: UpdateChecker?
-    
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.accessory)
-    }
-}
+final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
+    private let interceptor = KeyInterceptor.shared
+    let updateChecker = UpdateChecker()
 
-class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem?
     private var popover: NSPopover?
-    private let interceptor = KeyInterceptor.shared
     private var globalEventMonitor: Any?
     private var localEventMonitor: Any?
-    
+    private var updateCancellable: AnyCancellable?
+    private var permissionTimer: Timer?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Single-instance guard: if another copy is already running, defer to it.
         if let bundleID = Bundle.main.bundleIdentifier {
             let ownPID = ProcessInfo.processInfo.processIdentifier
-            let others = NSWorkspace.shared.runningApplications.filter { app in
-                app.bundleIdentifier == bundleID && app.processIdentifier != ownPID
+            let alreadyRunning = NSWorkspace.shared.runningApplications.contains {
+                $0.bundleIdentifier == bundleID && $0.processIdentifier != ownPID
             }
-            if let other = others.first {
-                other.activate(options: [.activateIgnoringOtherApps])
+            if alreadyRunning {
                 exit(0)
             }
         }
-        
+
+        // Run as a background agent: no Dock icon, no app-switcher entry.
         NSApp.setActivationPolicy(.accessory)
+
+        // The whole point of the app. It is started here — independent of the
+        // menu bar item — so it keeps running even if the icon is hidden.
         interceptor.start()
-        
-        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        
-        if let button = statusItem?.button {
-            // Use white Command symbol (⌘) as icon
+
+        setupStatusItem()
+        setupPopover()
+        observeUpdateAvailability()
+        setupPermissionHandling()
+
+        configureAutostart()
+        setupUpdateChecking()
+    }
+
+    // Never quit just because a window closed (e.g. the Settings window). The
+    // status item being hidden does not close a window, but this guarantees the
+    // agent — and the key interceptor — stays alive regardless.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    // MARK: - Menu bar item
+
+    private func setupStatusItem() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = item.button {
             let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
             let image = NSImage(systemSymbolName: "command", accessibilityDescription: "cmdX")
             button.image = image?.withSymbolConfiguration(config)
             button.action = #selector(togglePopover)
             button.target = self
         }
-        
-        popover = NSPopover()
-        popover?.contentSize = NSSize(width: 520, height: 280)
-        popover?.behavior = .transient
-    popover?.delegate = self
-        popover?.contentViewController = NSHostingController(rootView: ContentView().environmentObject(interceptor))
+        // Let the user hide it from the menu bar without quitting the app.
+        item.behavior = [.removalAllowed]
+        statusItem = item
+    }
 
-        let defaults = UserDefaults.standard
-        let configuredKey = "cmdx.autostart.configured"
-        if !defaults.bool(forKey: configuredKey) {
-            if #available(macOS 13.0, *) {
-                do {
-                    try SMAppService.mainApp.register()
-                    defaults.set(true, forKey: "cmdx.autostart.enabled")
-                } catch {
-                    setLaunchAtLogin(enabled: true)
-                    defaults.set(true, forKey: "cmdx.autostart.enabled")
-                }
-            } else {
-                setLaunchAtLogin(enabled: true)
-                defaults.set(true, forKey: "cmdx.autostart.enabled")
+    private func setupPopover() {
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: 520, height: 360)
+        popover.behavior = .transient
+        popover.delegate = self
+        popover.contentViewController = NSHostingController(
+            rootView: ContentView()
+                .environmentObject(interceptor)
+                .environmentObject(updateChecker)
+        )
+        self.popover = popover
+    }
+
+    /// Turns the menu bar icon red when an update is available (the old red dot).
+    private func observeUpdateAvailability() {
+        updateCancellable = updateChecker.$isUpdateAvailable
+            .receive(on: RunLoop.main)
+            .sink { [weak self] available in
+                self?.statusItem?.button?.contentTintColor = available ? .systemRed : nil
             }
-            defaults.set(true, forKey: configuredKey)
+    }
+
+    /// On launch, verifies Accessibility permission and prompts if it's missing.
+    /// Then polls so the popover's status stays live and the interceptor starts
+    /// automatically the moment the user grants access (no relaunch needed).
+    private func setupPermissionHandling() {
+        if !interceptor.refreshPermissionStatus() {
+            interceptor.promptForAccessibilityPermission()
         }
 
-    }
-    
-    @objc func togglePopover() {
-        if let button = statusItem?.button {
-            if let popover = popover {
-                if popover.isShown {
-                    popover.performClose(nil)
-                } else {
-                    popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-                    startEventMonitoring()
-                }
+        permissionTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            let granted = self.interceptor.refreshPermissionStatus()
+            if granted && !self.interceptor.isRunning {
+                self.interceptor.start()
             }
+        }
+    }
+
+    @objc private func togglePopover() {
+        guard let button = statusItem?.button, let popover = popover else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+            startEventMonitoring()
         }
     }
 
@@ -178,6 +172,46 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         stopEventMonitoring()
     }
 
+    // MARK: - Autostart
+
+    private func configureAutostart() {
+        let defaults = UserDefaults.standard
+        let configuredKey = "cmdx.autostart.configured"
+        guard !defaults.bool(forKey: configuredKey) else { return }
+
+        if #available(macOS 13.0, *) {
+            do {
+                try SMAppService.mainApp.register()
+            } catch {
+                setLaunchAtLogin(enabled: true)
+            }
+        } else {
+            setLaunchAtLogin(enabled: true)
+        }
+        defaults.set(true, forKey: "cmdx.autostart.enabled")
+        defaults.set(true, forKey: configuredKey)
+    }
+
+    // MARK: - Update checking
+
+    private func setupUpdateChecking() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if !granted {
+                print("DEBUG: Notification permission denied: \(error?.localizedDescription ?? "unknown")")
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.updateChecker.checkForUpdates()
+        }
+
+        Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { [weak self] _ in
+            self?.updateChecker.checkForUpdates()
+        }
+    }
+
+    // MARK: - Launch at login fallback (pre-macOS 13)
+
     private var bundleIdentifier: String {
         Bundle.main.bundleIdentifier ?? "com.yonn2222.cmdX"
     }
@@ -207,5 +241,4 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             try? fm.removeItem(at: plistURL)
         }
     }
-
 }


### PR DESCRIPTION
Closes #21
Closes #14

## What this does

Makes the key interceptor robust to the two things that were silently breaking ⌘X/⌘V, and surfaces Accessibility permission in the UI.

### Accessibility permission
- On launch, `AppDelegate` checks `AXIsProcessTrusted()` and shows the system prompt when access is missing.
- A lightweight poll keeps the status live and **auto-starts the interceptor the moment access is granted** — no relaunch needed.
- The popover now shows a live status card (**granted** / **needed**) with a **Grant Access…** button.
- `KeyInterceptor` publishes `hasAccessibilityPermission`; `start()` guards on it instead of failing silently.

### Survive the menu bar icon being hidden (macOS 26 / Tahoe)
- The app's lifetime was anchored to the single SwiftUI `MenuBarExtra` scene, so hiding/removing the menu bar item on Tahoe tore the scene down and terminated the whole process.
- Replaced it with a classic AppKit `NSStatusItem` owned by `AppDelegate`, an empty `Settings` scene, and `applicationShouldTerminateAfterLastWindowClosed == false`. The icon still shows (and respects the OS show/hide setting), but the app now runs as a background agent whose lifetime no longer depends on the menu bar item.
- This also delivers the **"Hide in menu bar"** feature requested in #14: because the app keeps running with no menu bar item, users can hide the ⌘ symbol via macOS 26's menu bar settings and cmdX continues to work.

### Keep the event tap alive
- Prevent App Nap via a held `ProcessInfo.beginActivity` token (still allows idle system sleep) — otherwise the throttled callback times out and the tap gets disabled when there's no visible UI.
- Re-enable the tap when the system disables it (`tapDisabledByTimeout` / `tapDisabledByUserInput`), instead of leaving it dead.

### Misc
- Updated the update notification text, which told users to open the app in the menu bar to install updates.

## Testing
- Built with Xcode 26.
- Verified: launches and prompts for Accessibility when missing; popover shows the correct live status; interception starts automatically on grant; ⌘X/⌘V keep working after the menu bar icon is hidden.

## Notes for reviewers
- This consolidates the two previous `NSApplicationDelegate` classes (`AppDelegateWrapper` and the unused `AppDelegate`) into one.
- `ContentView` is now hosted in the `NSStatusItem` popover rather than a `MenuBarExtra`.
