### PR TITLE
fix: distinguish failed update checks from no update

### DIFF
--- a/cmdX/UpdateChecker.swift
+++ b/cmdX/UpdateChecker.swift
@@ -41,12 +41,23 @@ class UpdateChecker: NSObject, ObservableObject, UNUserNotificationCenterDelegat
         let url = URL(string: "https://api.github.com/repos/YONN2222/cmdX/releases/latest")!
         
         URLSession.shared.dataTask(with: url) { data, response, error in
-            guard let data = data, error == nil else {
-                if manualCheck {
-                    DispatchQueue.main.async {
-                        self.showNoUpdateAlert()
-                    }
-                }
+            if let error {
+                self.handleUpdateCheckFailure(error.localizedDescription, manualCheck: manualCheck)
+                return
+            }
+
+            guard let data else {
+                self.handleUpdateCheckFailure("The server returned no data.", manualCheck: manualCheck)
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                self.handleUpdateCheckFailure("The server returned an invalid response.", manualCheck: manualCheck)
+                return
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                self.handleUpdateCheckFailure("GitHub returned HTTP \(httpResponse.statusCode).", manualCheck: manualCheck)
                 return
             }
             
@@ -89,8 +100,19 @@ class UpdateChecker: NSObject, ObservableObject, UNUserNotificationCenterDelegat
                         }
                     }
                 }
+            } else {
+                self.handleUpdateCheckFailure("The server response could not be decoded.", manualCheck: manualCheck)
             }
         }.resume()
+    }
+
+    private func handleUpdateCheckFailure(_ reason: String, manualCheck: Bool) {
+        NSLog("cmdX: update check failed - \(reason)")
+        guard manualCheck else { return }
+
+        DispatchQueue.main.async {
+            self.showUpdateCheckFailedAlert()
+        }
     }
 
     private func isNewer(latestVersion: String, currentVersion: String) -> Bool {
@@ -181,6 +203,15 @@ class UpdateChecker: NSObject, ObservableObject, UNUserNotificationCenterDelegat
             alert.addButton(withTitle: "OK")
             alert.runModal()
         }
+    }
+
+    private func showUpdateCheckFailedAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Unable to Check for Updates"
+        alert.informativeText = "cmdX couldn't check for updates. Check your internet connection and try again."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }
 


### PR DESCRIPTION
## Problem

When a manual update request fails at the network layer, cmdX currently reports "No Update Available," which incorrectly implies that the check succeeded. Non-2xx responses and unexpected JSON can leave the manual check without feedback.

## Change

Validate the HTTP response before decoding and route transport, response, status, and decoding failures through one handler. Manual failures show "Unable to Check for Updates" and log the reason; automatic failures only log it.

This changes only `UpdateChecker.swift` and adds no dependencies. It also addresses the unresolved transport and decoding feedback from PR #11.

## Validation

- Checked the live GitHub endpoint (200, release 1.5.2): existing no-update path.
- Exercised offline transport failure, HTTP 404, and HTTP 200 with invalid JSON using a local URLProtocol harness. Each reached the expected failure log.
- Confirmed automatic failures do not enqueue the manual alert.
- Type-checked the changed source with the project's main-actor isolation and compiled all app Swift sources with Apple Swift 6.3.3.

A full xcodebuild was not run because this environment has Command Line Tools rather than full Xcode.