### PR TITLE
fix: invalidate cut when pasteboard changes

### DIFF
--- a/cmdX/KeyInterceptor.swift
+++ b/cmdX/KeyInterceptor.swift
@@ -10,7 +10,7 @@ final class KeyInterceptor: ObservableObject {
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
 
-    private var cutPending = false
+    private var cutPasteboardState = CutPasteboardState()
 
     fileprivate static let syntheticMarker: Int64 = 0x636D_6458
 
@@ -56,7 +56,7 @@ final class KeyInterceptor: ObservableObject {
         runLoopSource = nil
         eventTap = nil
         isRunning = false
-        cutPending = false
+        cancelCut()
         NSLog("cmdX: event tap stopped")
     }
 
@@ -90,22 +90,18 @@ final class KeyInterceptor: ObservableObject {
 
         switch CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode)) {
         case Keycode.x:
-            shared.cutPending = true
-            shared.publishCutState(true)
+            shared.beginCut()
             postShortcut(keyCode: Keycode.c, flags: [.maskCommand])
             return nil
 
         case Keycode.c:
-            shared.cutPending = false
-            shared.publishCutState(false)
+            shared.cancelCut()
             return Unmanaged.passUnretained(event)
 
         case Keycode.v:
-            guard shared.cutPending else {
+            guard shared.consumeCutIfPasteboardIsCurrent() else {
                 return Unmanaged.passUnretained(event)
             }
-            shared.cutPending = false
-            shared.publishCutState(false)
             postShortcut(keyCode: Keycode.v, flags: [.maskCommand, .maskAlternate])
             return nil
 
@@ -114,10 +110,46 @@ final class KeyInterceptor: ObservableObject {
         }
     }
 
+    private func beginCut() {
+        cutPasteboardState.begin(currentChangeCount: NSPasteboard.general.changeCount)
+        publishCutState(true)
+    }
+
+    private func cancelCut() {
+        cutPasteboardState.cancel()
+        publishCutState(false)
+    }
+
+    private func consumeCutIfPasteboardIsCurrent() -> Bool {
+        let shouldMove = cutPasteboardState.consume(
+            currentChangeCount: NSPasteboard.general.changeCount
+        )
+        publishCutState(false)
+        return shouldMove
+    }
+
     private func publishCutState(_ value: Bool) {
         DispatchQueue.main.async {
             self.lastActionWasCut = value
         }
+    }
+}
+
+struct CutPasteboardState {
+    private var expectedChangeCount: Int?
+
+    mutating func begin(currentChangeCount: Int) {
+        // Finder takes pasteboard ownership once when it handles the synthetic Cmd-C.
+        expectedChangeCount = currentChangeCount &+ 1
+    }
+
+    mutating func cancel() {
+        expectedChangeCount = nil
+    }
+
+    mutating func consume(currentChangeCount: Int) -> Bool {
+        defer { cancel() }
+        return expectedChangeCount == currentChangeCount
     }
 }
 


### PR DESCRIPTION
## Problem

A pending cut can incorrectly turn a later copy into a move:

1. In Finder, cut `report-to-move.txt` with `Cmd-X`.
2. Select `notes-to-copy.txt` and choose **Copy** from Finder's context menu.
3. Press `Cmd-V` in another folder.

Expected: `notes-to-copy.txt` is copied and its source stays in place. Instead, the stale cut state causes cmdX to send `Cmd-Option-V`, moving the copied file. I reproduced the underlying issue on 1.5.2 by replacing the pasteboard programmatically after cutting a file, simulating a non-keyboard copy.

## Relationship to #19

Follow-up requested in https://github.com/YONN2222/cmdX/pull/19#issuecomment-5600699181. This PR targets `dev` and contains one commit on top of the merged #19.

#19 prevents cmdX's synthetic `Cmd-C` from cancelling a valid cut. This change invalidates a cut when an unrelated operation replaces the pasteboard without a `Cmd-C` key event. It preserves #19's synthetic-event marker, event-tap recovery, shortcut handling, and UI-mirror design.

## Change

Record the current `NSPasteboard.general.changeCount` before posting the synthetic `Cmd-C`, expecting Finder's copy to increment it once. On paste, move only if the count matches; otherwise clear the stale cut and pass the original `Cmd-V` through. Either path consumes the cut once. Stop and explicit copy use the same cancellation path.

Only `KeyInterceptor.swift` changes. No timers, polling, clipboard-content inspection, dependencies, extensions, or permissions are added.

## Validation and limitations

- Local state-machine harness passed for valid/replaced/unchanged pasteboards, one-shot consumption, repeated cut, cancellation, and counter wraparound.
- All Swift app sources compiled against current `dev` with Apple Swift 6.3.3, Swift 5 mode, and the project's main-actor isolation.
- `git diff --check` passed. No full Xcode build or end-to-end Finder test of the patched build was performed.

A clipboard manager rewriting identical content conservatively cancels the cut. The counter cannot distinguish a failed synthetic copy (e.g. no valid selection) followed by exactly one unrelated copy; this patch addresses a valid file cut followed by pasteboard replacement without introducing selection inspection or polling.